### PR TITLE
Fixed an issue with 'where' fields in delete query

### DIFF
--- a/lib/querybuilder.js
+++ b/lib/querybuilder.js
@@ -210,7 +210,7 @@ QueryBuilder.prototype.getJSON = function () {
 };
 
 QueryBuilder.prototype.isValid = function () {
-  return this.fields.length || this.queryType === 3;
+  return this.fields.length || this.queryType === 3 || this.whereFields.length || this.whereContainsFields.length;
 };
 
 QueryBuilder.prototype.dump = function () {


### PR DESCRIPTION
In case of delete query where and whereContains fields get ignore, isValid() returns false in such cases.
